### PR TITLE
Extend database check

### DIFF
--- a/src/Session/SqliteSessionHandler.php
+++ b/src/Session/SqliteSessionHandler.php
@@ -54,10 +54,7 @@ class SqliteSessionHandler implements SessionHandlerInterface, LoggerAwareInterf
         $this->lifetime = (int)ini_get('session.gc_maxlifetime');
 
         $dbLocation = sprintf('%s/connector.s3db', $databaseDir);
-        if (!file_exists($dbLocation))
-        {
-          $isNew = true;
-        }
+   $isNew = !file_exists($dbLocation);
 
         $sqlite3 = new Sqlite3();
         $sqlite3->connect(['location' => $dbLocation]);

--- a/src/Session/SqliteSessionHandler.php
+++ b/src/Session/SqliteSessionHandler.php
@@ -53,8 +53,14 @@ class SqliteSessionHandler implements SessionHandlerInterface, LoggerAwareInterf
         $this->logger = new NullLogger();
         $this->lifetime = (int)ini_get('session.gc_maxlifetime');
 
+        $dbLocation = sprintf('%s/connector.s3db', $databaseDir);
+        if (!file_exists($dbLocation))
+        {
+          $isNew = true;
+        }
+
         $sqlite3 = new Sqlite3();
-        $sqlite3->connect(['location' => sprintf('%s/connector.s3db', $databaseDir)]);
+        $sqlite3->connect(['location' => $dbLocation]);
         $this->db = $sqlite3;
 
         if ($isNew) {

--- a/src/Session/SqliteSessionHandler.php
+++ b/src/Session/SqliteSessionHandler.php
@@ -43,18 +43,16 @@ class SqliteSessionHandler implements SessionHandlerInterface, LoggerAwareInterf
      */
     public function __construct(string $databaseDir)
     {
-        $isNew = false;
         if (!is_dir($databaseDir)) {
             if (!mkdir($databaseDir)) {
                 throw new SessionException('Could not create sqlite database directory');
             }
-            $isNew = true;
         }
         $this->logger = new NullLogger();
         $this->lifetime = (int)ini_get('session.gc_maxlifetime');
 
         $dbLocation = sprintf('%s/connector.s3db', $databaseDir);
-   $isNew = !file_exists($dbLocation);
+        $isNew = !file_exists($dbLocation);
 
         $sqlite3 = new Sqlite3();
         $sqlite3->connect(['location' => $dbLocation]);


### PR DESCRIPTION
By starting the application it will be create the var-folder, so that the check will be false on every time and the script doesn't initialize the session tables. For fixing this the constructor takes a closer view if the sqlite-file exists. If not it knows that it is a new Sqlite-database.