### PR TITLE
In PHP 8.1 an error is showhing up when using connector-core (LoggerAwareInterface)

### DIFF
--- a/src/Controller/ConnectorController.php
+++ b/src/Controller/ConnectorController.php
@@ -274,7 +274,7 @@ class ConnectorController implements LoggerAwareInterface
     /**
      * @param LoggerInterface $logger
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger):void
     {
         $this->logger = $logger;
     }

--- a/src/Database/Sqlite3.php
+++ b/src/Database/Sqlite3.php
@@ -269,9 +269,8 @@ class Sqlite3 implements DatabaseInterface, LoggerAwareInterface
      * @param LoggerInterface $logger
      * @return Sqlite3
      */
-    public function setLogger(LoggerInterface $logger): Sqlite3
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
-        return $this;
     }
 }

--- a/src/Http/JsonResponse.php
+++ b/src/Http/JsonResponse.php
@@ -72,7 +72,7 @@ class JsonResponse extends SymfonyJsonResponse implements LoggerAwareInterface
     /**
      * @param LoggerInterface $logger
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger):void
     {
         $this->logger = $logger;
     }

--- a/src/Linker/ChecksumLinker.php
+++ b/src/Linker/ChecksumLinker.php
@@ -93,7 +93,7 @@ class ChecksumLinker implements LoggerAwareInterface
     /**
      * @param LoggerInterface $logger
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger):void
     {
         $this->logger = $logger;
     }

--- a/src/Linker/IdentityLinker.php
+++ b/src/Linker/IdentityLinker.php
@@ -387,7 +387,7 @@ class IdentityLinker implements LoggerAwareInterface
     /**
      * @param LoggerInterface $logger
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger):void
     {
         $this->logger = $logger;
     }

--- a/src/Session/SqliteSessionHandler.php
+++ b/src/Session/SqliteSessionHandler.php
@@ -208,7 +208,7 @@ class SqliteSessionHandler implements SessionHandlerInterface, LoggerAwareInterf
     /**
      * @param LoggerInterface $logger
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger):void
     {
         $this->logger = $logger;
         $this->db->setLogger($logger);


### PR DESCRIPTION
Since the support of PHP 7.4 ends in november it is important to migrate to PHP 8.1.

When doing so an error occurs because the setLogger Method in the LoggerAwareInterface from Psr is declared with return type.

I updated all necessary methods.