### PR TITLE
call `$controller->commit()` outside of foreach loop

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -993,10 +993,10 @@ class Application
                             $checksumLinker->link($dataModel);
                         }
                         $result[] = $dataModel;
+                    }
 
-                        if ($controller instanceof TransactionalInterface) {
-                            $controller->commit();
-                        }
+                    if ($controller instanceof TransactionalInterface) {
+                        $controller->commit();
                     }
                 } catch (Throwable $ex) {
                     if ($controller instanceof TransactionalInterface) {


### PR DESCRIPTION
Commit b3b00eb broke the `TransactionalInterface` Controller handling. It starts the transaction with `$controller->beginTransaction()` at the beginning, calls the `$controller->commit()` however multiple times inside the `foreach` loop which should only happen once at the end of the `try...catch` block because you can't commit a transaction more than once. This will throw if more than 1 model has been passed to a Controller which implements the `TransactionalInterface`.